### PR TITLE
Support absolute links

### DIFF
--- a/src/validation.rs
+++ b/src/validation.rs
@@ -91,7 +91,12 @@ fn check_link_in_book(
     }
 
     let chapter_dir = absolute_chapter_path.parent().unwrap();
-    let target = chapter_dir.join(path);
+    let target =
+        if path.is_absolute() {
+            ctx.source_dir().join(path.strip_prefix("/").unwrap())
+        } else {
+            chapter_dir.join(path)
+        };
 
     debug!(
         "Searching for \"{}\" from {}#{}",

--- a/tests/all-green/src/chapter_1.md
+++ b/tests/all-green/src/chapter_1.md
@@ -4,6 +4,8 @@
 
 [Link to a nested directory](nested/index.md)
 
+## Subheading
+
 [And also external web pages](https://www.google.com/)
 
 [You can also blacklist URLs by regex](https://nonexistent.forbidden.com/)

--- a/tests/all-green/src/nested/index.md
+++ b/tests/all-green/src/nested/index.md
@@ -1,3 +1,4 @@
 # Nested Directory
 
 [All links are relative](../chapter_1.md)
+[This link is absolute](/chapter_1.md)

--- a/tests/all-green/src/nested/index.md
+++ b/tests/all-green/src/nested/index.md
@@ -1,4 +1,9 @@
 # Nested Directory
 
 [All links are relative](../chapter_1.md)
-[This link is absolute](/chapter_1.md)
+But so is the above statement, because [this link is absolute](/chapter_1.md) :P
+
+[Relative with anchor](../chapter_1.md#Subheading)
+[Absolute with anchor](/chapter_1.md#Subheading)
+[Relative sibling](sibling.md)
+[Relative sibling dot slash](./sibling.md)

--- a/tests/all-green/src/nested/sibling.md
+++ b/tests/all-green/src/nested/sibling.md
@@ -1,0 +1,1 @@
+# Sibling chapter

--- a/tests/broken-links/src/deeply/nested/index.md
+++ b/tests/broken-links/src/deeply/nested/index.md
@@ -1,8 +1,7 @@
 # Deeply Nested Chapter
 
-We can link to [chapter 1](../../chapter_1.md) using relative links, but
-[absolute links](/chapter_1.md) or links [relative to the root](./chapter_1.md)
-won't work.
+We can link to [chapter 1](../../chapter_1.md) using relative links, but links
+[relative to the root](./chapter_1.md) won't work.
 
 Linking to a [sibling directory](./second/directory.md) relative to the source
 root won't work either. We need to specify a link [relative to

--- a/tests/smoke_tests.rs
+++ b/tests/smoke_tests.rs
@@ -27,7 +27,7 @@ fn book_with_broken_links() {
     let broken_links = result.downcast_ref::<BrokenLinks>().unwrap();
     let links = broken_links.links();
 
-    assert_eq!(links.len(), 6);
+    assert_eq!(links.len(), 5);
 
     let non_existent_url =
         links[0].as_fail().downcast_ref::<HttpError>().unwrap();
@@ -51,14 +51,11 @@ fn book_with_broken_links() {
 
     // Nested links which are relative to the book root instead of the current
     // file are errors
-    let deeply_nested_absolute =
-        links[3].as_fail().downcast_ref::<FileNotFound>().unwrap();
-    assert_eq!(deeply_nested_absolute.path, Path::new("/chapter_1.md"));
     let deeply_nested_relative =
-        links[4].as_fail().downcast_ref::<FileNotFound>().unwrap();
+        links[3].as_fail().downcast_ref::<FileNotFound>().unwrap();
     assert_eq!(deeply_nested_relative.path, Path::new("./chapter_1.md"));
     let other_nested =
-        links[5].as_fail().downcast_ref::<FileNotFound>().unwrap();
+        links[4].as_fail().downcast_ref::<FileNotFound>().unwrap();
     assert_eq!(other_nested.path, Path::new("./second/directory.md"));
 }
 


### PR DESCRIPTION
They appear to be supported just fine in mdbook 0.2.1, I'm using them
extensively.