### PR TITLE
Turn off gh-pages history.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ deploy:
   - provider: pages
     skip-cleanup: true
     github-token: "$GITHUB_TOKEN"
-    keep-history: true
+    keep-history: false
     local-dir: target/doc
     on:
       branch: master


### PR DESCRIPTION
Just a suggestion, the repo size has gotten quite large (over 80MB), almost all of it in the gh-pages branch.  I personally don't think it is necessary to keep the history, since this information can be rebuilt at any time, and it just ends up making cloning the repo slow.  
