### PR TITLE
Support for custom HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,25 @@ cache-timeout = 43200
 # - "ignore" will ignore warnings, suppressing diagnostic messages and allowing
 #   the linkcheck to continuing
 warning-policy = "warn"
+
+# Extra HTTP headers that must be send to certain web sites
+# in order to link check to succeed
+#
+# This is a dictionary (map), with keys being regexes
+# matching a set of web sites, and values being an array of
+# the headers.
+[http-headers]
+# Any hyperlink that contains this regexp will be sent
+# the "Accept: text/html" header
+"crates\.io" = ["Accept: text/html"]
+
+# mdbook-linkcheck will interpolate environment variables
+# into your header via $IDENT.
+#
+# If this is not what you want
+# you must escape the `$` symbol, like `\$TOKEN`. `\` itself can also be escaped
+# via `\\`.
+"website\.com" = ["Authorization: Basic $TOKEN"]
 ```
 
 [releases]: https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases

--- a/src/hashed_regex.rs
+++ b/src/hashed_regex.rs
@@ -1,0 +1,90 @@
+use regex::Regex;
+use serde::{Serialize, Deserialize, Deserializer, de::Error};
+use std::{
+    hash::{Hash, Hasher},
+    ops::Deref,
+    str::FromStr
+};
+
+/// A wrapper around [`regex::Regex`] which implements **string repr based**
+/// [`Serialize`], [`Deserialize`], [`PartialEq`], [`Eq`], [`Hash`].
+///
+/// It also implements `Deref<Target=Regex>` and [`FromStr`] for convenience.
+///
+/// # Important
+///
+/// **All the implementations are string based**. It means that the said
+/// implementations simply delegate to the underlying implementations for `str`.
+///
+/// For example, while `[0-9]*` and `\d*` are the same regex, they will be considered
+/// different. In particular, the following is true:
+/// ```
+/// use mdbook_linkcheck::HashedRegex;
+///
+/// assert_ne!(
+///     HashedRegex::new("[0-9]*").unwrap(),
+///     HashedRegex::new(r"\d*").unwrap()
+/// );
+/// ```
+#[derive(Serialize, Debug, Clone)]
+#[serde(transparent)]
+pub struct HashedRegex {
+    /// String representation.
+    pub string: String,
+
+    /// Compiled regexp.
+    #[serde(skip_serializing)]
+    pub re: Regex
+}
+
+impl HashedRegex {
+    /// Create new [`HashedRegex`] instance.
+    pub fn new(s: &str) -> Result<Self, regex::Error> {
+        let string = s.to_string();
+        let re = Regex::new(s)?;
+
+        Ok(HashedRegex { string, re })
+    }
+}
+
+impl<'de> Deserialize<'de> for HashedRegex {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>
+    {
+        let string = String::deserialize(deserializer)?;
+        let re = Regex::new(&string).map_err(D::Error::custom)?;
+
+        Ok(HashedRegex { string, re })
+    }
+}
+
+impl Hash for HashedRegex {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.string.hash(state);
+    }
+}
+
+impl PartialEq for HashedRegex {
+    fn eq(&self, other: &Self) -> bool {
+        self.string == other.string
+    }
+}
+
+impl Eq for HashedRegex {}
+
+impl FromStr for HashedRegex {
+    type Err = regex::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        HashedRegex::new(s)
+    }
+}
+
+impl Deref for HashedRegex {
+    type Target = regex::Regex;
+
+    fn deref(&self) -> &regex::Regex {
+        &self.re
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,11 +27,13 @@ mod cache;
 mod config;
 mod links;
 mod validate;
+mod hashed_regex;
 
 pub use crate::{
     cache::Cache,
     config::{Config, WarningPolicy},
     links::{extract as extract_links, IncompleteLink, Link},
+    hashed_regex::HashedRegex,
     validate::{
         validate, InvalidLink, Reason, UnknownScheme, ValidationOutcome,
     },

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -269,7 +269,8 @@ fn check_link(
         if pattern.find(&url).is_some() {
             log::trace!("Applying extra headers to `{}`", url);
             for header in headers {
-                request = request.header(&header.name, &header.value);
+                log::trace!("  Applying `{}`", header.interpolated_value);
+                request = request.header(&header.name, &header.interpolated_value);
             }
         }
     }

--- a/tests/all-green/src/chapter_1.md
+++ b/tests/all-green/src/chapter_1.md
@@ -9,4 +9,6 @@
 
 [And also external web pages](https://www.google.com/)
 
+[Some web links require additional HTTP headers](https://crates.io/crates/mdbook-linkcheck)
+
 [You can also blacklist URLs by regex](https://nonexistent.forbidden.com/)

--- a/tests/smoke_tests.rs
+++ b/tests/smoke_tests.rs
@@ -6,6 +6,8 @@ use failure::Error;
 use mdbook::{renderer::RenderContext, MDBook};
 use mdbook_linkcheck::{Cache, Config, ValidationOutcome};
 use std::path::{Path, PathBuf};
+use regex::Regex;
+use std::convert::TryInto;
 
 fn test_dir() -> PathBuf { Path::new(env!("CARGO_MANIFEST_DIR")).join("tests") }
 
@@ -22,6 +24,7 @@ fn check_all_links_in_a_valid_book() {
         "/chapter_1.md",
         "./sibling.md",
         "https://www.google.com/",
+        "https://crates.io/crates/mdbook-linkcheck"
     ];
 
     let output = run_link_checker(&root).unwrap();
@@ -90,6 +93,14 @@ fn run_link_checker(root: &Path) -> Result<ValidationOutcome, Error> {
         follow_web_links: true,
         traverse_parent_directories: false,
         exclude: vec![r"forbidden\.com".parse().unwrap()],
+        http_headers: vec![
+            (
+                Regex::new(r"crates\.io").unwrap(),
+                vec![
+                    "Accept: text/html".try_into().unwrap()
+                ]
+            )
+        ],
         ..Default::default()
     };
     md.config.set("output.linkcheck", &cfg).unwrap();


### PR DESCRIPTION
Closes #22 

## What is implemented

```toml
[http-headers]
#regexp = [headers]
"https?://" = ["Accept: text/html", "..."]
```

## Bugs fixed
* Old code didn't compare the `exclude` array properly, for example, if one was a prefix of the another, they would be considered equal (hint: `Iterator::zip` is short-cutting 😄 ). This is fixed.

## What is not implemented
Environment variables interpolation. I agree this is pretty easy to implement, but I'd like to clarify the syntax. `$` + ident? maybe also `\$` escape...

## Further improvements 
In my opinion, it would be better to use some wrapper in place of `Regex`, implementing string-based `Hash`, `Serialize`, `Deserialize`, `PartialEq` for it. It would greatly simplify certain parts of the code, but that would be a breaking change since you'd already put a `Regex` in the public API (the `exclude` array).

## TODO
Tests (how should they look like?) and documentation.
