### PR TITLE
Adhere to follow_web_links setting when overriding context

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -34,6 +34,12 @@ impl<'a> linkcheck::validation::Context for Context<'a> {
     }
 
     fn should_ignore(&self, link: &Link) -> bool {
+        if !self.cfg.follow_web_links {
+            if let Ok(_) = link.href.parse::<Url>() {
+                return true;
+            }
+        }
+
         self.cfg
             .exclude
             .iter()

--- a/tests/external-links/book.toml
+++ b/tests/external-links/book.toml
@@ -1,0 +1,10 @@
+[book]
+authors = ["Michael Bryan"]
+multilingual = false
+src = "src"
+title = "External links"
+
+[output.linkcheck]
+follow-web-links = false
+
+[output.html]

--- a/tests/external-links/src/SUMMARY.md
+++ b/tests/external-links/src/SUMMARY.md
@@ -1,0 +1,5 @@
+# Summary
+
+- [Chapter 1](./chapter_1.md)
+- [Nested Directory](./nested/README.md)
+  - [Sibling](./nested/sibling.md)

--- a/tests/external-links/src/chapter_1.md
+++ b/tests/external-links/src/chapter_1.md
@@ -1,0 +1,15 @@
+# Chapter 1
+
+[This links to itself](./chapter_1.md)
+[This links to itself using the HTML extension](./chapter_1.html)
+
+[Link to a nested directory](nested/README.md). You can also link to
+[the directory](nested/) directly and it'll be rewritten to `README.md`.
+
+## Subheading
+
+[This external link will not be checked](https://www.google.com/)
+
+[This external link will not be checked](https://crates.io/crates/mdbook-linkcheck)
+
+[This external link will not be checked](https://nonexistent.forbidden.com/)

--- a/tests/external-links/src/nested/README.md
+++ b/tests/external-links/src/nested/README.md
@@ -1,0 +1,9 @@
+# Nested Directory
+
+[All links are relative](../chapter_1.md)
+But so is the above statement, because [this link is absolute](/chapter_1.md) :P
+
+[Relative with anchor](../chapter_1.md#Subheading)
+[Absolute with anchor](/chapter_1.md#Subheading)
+[Relative sibling](sibling.md)
+[Relative sibling dot slash](./sibling.md)

--- a/tests/external-links/src/nested/sibling.md
+++ b/tests/external-links/src/nested/sibling.md
@@ -1,0 +1,1 @@
+# Sibling chapter


### PR DESCRIPTION
Closes #38.

The solution isn't 100% satisfying as it basically duplicates the [categorization logic from `linkcheck`](https://github.com/Michael-F-Bryan/linkcheck/blob/master/src/lib.rs#L104). It could perhaps be implemented more cleanly by exposing the `Category` enum but I'm not sure if that would be worth it. Let me know what you think!

I added a test book which is a copy of the "all-green" book except with config and link texts that indicate what the expected result is. `TestRun` now optionally takes a `Config` to allow setting `follow_web_links` to false.