### PR TITLE
Add flag to disable caching

### DIFF
--- a/src/bin/mdbook-linkcheck.rs
+++ b/src/bin/mdbook-linkcheck.rs
@@ -21,7 +21,12 @@ fn main() -> Result<(), Error> {
     };
 
     let cache_file = ctx.destination.join("cache.json");
-    mdbook_linkcheck::run(&cache_file, args.colour, &ctx, args.selected_files)
+    let cache_file = if args.no_cache {
+        None
+    } else {
+        Some(cache_file.as_path())
+    };
+    mdbook_linkcheck::run(cache_file, args.colour, &ctx, args.selected_files)
 }
 
 #[derive(Debug, Clone, StructOpt)]
@@ -53,6 +58,11 @@ struct Args {
         help = "Check only the given files (check all files if omitted)."
     )]
     selected_files: Option<Vec<String>>,
+    #[structopt(
+        long = "no-cache",
+        help = "Ignore any existing cache, neither using nor updating it."
+    )]
+    no_cache: bool,
 }
 
 fn parse_colour(raw: &str) -> Result<ColorChoice, Error> {


### PR DESCRIPTION
This PR adds the `--no-cache` flag. This flag is intended to pair with the `--files` flag.

The idea is that sometimes you want to do a full linkcheck of the whole mdbook, in which case caching is very useful. At other times, though, we only want to check a handful of changed files, and in this case, it is nice to just do a full check, independent of what might be in the cache from files not being checked.

cc @camelid 