### PR TITLE
Fix upload of precompiled binaries to release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Publish the Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "public/*.zip"
+          artifacts: "public/mdbook-linkcheck-*/*.zip"
           body: |
             Released ${{ github.ref }}.
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Due to a path missmatch the precompiled binaries weren't uploaded to the release assets #61 (https://github.com/Michael-F-Bryan/mdbook-linkcheck/actions/runs/1204764144) . Therefore I adjusted the path to the downloaded artifacts.

Further releases should now contain the precompiled macos, linux and windows binaries again. I tested this on my fork.

Close #61 