### PR TITLE
Run release CI on ubuntu 18.04 for better glibc compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         ]
         include:
           - name: linux
-            os: ubuntu-latest
+            os: ubuntu-18.04
             artifact_name: "target/dist/*.zip"
             asset_name: mdbook-linkcheck-linux
           - name: windows


### PR DESCRIPTION
the version of glibc that the binary gets built with is forwards compatible to new versions of glibc but not backwards compatible.

That means if we build on ubuntu 20.04 we can only run on ubuntu 20.04 and any future versions.
But if we build on ubuntu 18.04 we can run on ubuntu 18.04 and ubuntu 20.04 and any future versions.

This PR makes use of this to support more environments.

A particular point of trouble for me was running mdbook-linkcheck on netlify which doesnt seem to let me run on a newer os.
![image](https://user-images.githubusercontent.com/5120858/141425715-f36e6088-3600-47f6-b9be-20a02d9c3662.png)
